### PR TITLE
stop observer in timeout

### DIFF
--- a/lib/reactive-publish.coffee
+++ b/lib/reactive-publish.coffee
@@ -18,7 +18,8 @@ parent = override Cursor.prototype,
 		handle = Deps.nonreactive => parent.observeChanges(@, callbacks)
 		if Deps.active and @._cursorDescription.options.reactive
 			Deps.onInvalidate ->
-				handle.stop()
+				Meteor.setTimeout ->
+					handle.stop()
 		handle
 		
 	_depend: (changers) ->


### PR DESCRIPTION
fixes changed callbacks not being fired
when the cursor which is returned from
reactivePublish is also watched with
{ reactive: true }
